### PR TITLE
fix: make git diff invocation posix compliant

### DIFF
--- a/.changeset/dry-points-reply.md
+++ b/.changeset/dry-points-reply.md
@@ -1,0 +1,5 @@
+---
+"changesets-release-it-plugin": patch
+---
+
+make diff invocation posix compliant

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ export default class ChangesetPlugin extends Plugin {
     await this.exec("npx changeset status");
     try {
       this.log.info("Checking difference between head and upstream");
-      await this.exec("[[ ! $(git diff @ @{upstream}) ]]");
+      await this.exec("test -z $(git diff @ @{upstream})");
     } catch (e) {
       this.log.error(
         "HEAD must be up to date with upstream, please push or pull your changes"


### PR DESCRIPTION
use posix test instead of bashism for diff test

I looked into using nodegit as well, which is theoretically a better solution, 
but that introduces node-gyp and that is a pain on nixos, so I figured
I'd take the middle road.

fixes #5