### PR TITLE
Add support for 2 very restrictive monorepo set-ups

### DIFF
--- a/.changeset/twenty-wasps-cheer.md
+++ b/.changeset/twenty-wasps-cheer.md
@@ -1,0 +1,5 @@
+---
+"changesets-release-it-plugin": minor
+---
+
+Backwards compatible addition to handle very simple monorepo set-ups

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # changesets-release-it-plugin
 
-> **Warning**
+> [!WARNING]
 > This plugin is highly experimental, use at your own risk
 > 
-> In particular, this plugin does not yet properly support monorepos
+> In particular, only certain monorepo configurations are supported
 
 
 The idea of this plugin is to combine the excellent changelog management from [changesets](https://github.com/changesets/changesets) with the 
@@ -37,3 +37,23 @@ NOTE: If you don't use the publish feature of the npm plugin, you can simply dis
   "allowSameVersion": true
 }
 ```
+
+## Monorepos
+
+Due to the way that release-it handles tagging and releasing it is [only possible to support very constrained monorepo version configurations](https://github.com/release-it/release-it/blob/main/docs/recipes/monorepo.md).
+There are two options that should work (it's also possible that a combination will work):
+
+### All packages released under the same version number
+
+For this set-up you will need to set the same version number in the `package.json` of each package in the workspace.
+You then need to change your changesets configuration to have all of your packages in the `fixed` array.
+
+Whenever you run release-it, all of the packages will be released with the new, same version number, each with their own changelog.
+There will be one tag created with the new version number.
+
+### Only one versioned package
+
+If you have only one package in your workspace that you want to release, you can instead just version that and ignore the others.
+You need to remove the version number from the `package.json` of all but the versioned package and add the non-versioned package names to the `ignore` array in the changeset configuration.
+
+When you run release-it, you'll get a tag of the new version and any linked dependencies will be updated but there will be no changelog for the non-versioned packages.

--- a/index.js
+++ b/index.js
@@ -59,16 +59,6 @@ export function getChangelogEntry(changelog, version) {
   };
 }
 
-export function sortTheThings(a, b) {
-  if (a.private === b.private) {
-    return b.highestLevel - a.highestLevel;
-  }
-  if (a.private) {
-    return 1;
-  }
-  return -1;
-}
-
 export default class ChangesetPlugin extends Plugin {
   async init() {
     this.log.info("Validating changeset status");
@@ -85,20 +75,42 @@ export default class ChangesetPlugin extends Plugin {
   }
   beforeBump() {}
   async getChangelog() {
-    this.log.info("Collecting changesets and bumping version with: $ npx changeset version");
+    this.log.info("Collecting changesets and bumping version(s) with: $ npx changeset version");
     await this.exec("npx changeset version");
 
-    this.log.info("Parsing package.json to get new version");
-    const { rootPackage } = await getPackages(process.cwd());
-    const newVersion = rootPackage.packageJson.version;
-    this.log.info(`Found new version ${newVersion}`);
-    this.setContext({ newVersion });
-
-    this.log.info("Parsing changelog file for new entry");
-    const changelogFileName = path.join("CHANGELOG.md");
-    const changelog = await fs.readFile(changelogFileName, "utf8");
-    const { content } = getChangelogEntry(changelog, newVersion);
-    return content;
+    this.log.info("Collecting workspace information");
+    const { packages } = await getPackages(process.cwd());
+    let onlyContent = false;
+    let newVersion;
+    for (const pkg of packages) {
+      this.log.info(`Parsing ${pkg.relativeDir}/package.json to get new version`);
+      const packageVersion = pkg.packageJson.version;
+      if (packageVersion) {
+        if (!newVersion || newVersion === packageVersion) {
+          newVersion = packageVersion;
+          this.log.info(`Found new version in '${pkg.relativeDir}/': ${newVersion}`);
+          this.setContext({ newVersion });
+        } else {
+          this.log.error(
+            "This plugin doesn't support monorepos with different package versions",
+            "due to how release-it works. You'll either need to set all packages",
+            "to the same version and set them to \"fixed\" in your changeset config,",
+            "or have only one workspace package with a version in the package.json",
+            "and ignore all other packages in your changeset config",
+          );
+          throw new Error("Unsupported monorepo versions");
+        }
+      }
+      this.log.info("Parsing changelog file for new entry");
+      const changelogFileName = path.join(pkg.relativeDir, "CHANGELOG.md");
+      const changelog = await fs.readFile(changelogFileName, "utf8");
+      const { content } = getChangelogEntry(changelog, newVersion);
+      if (packages.length === 1) {
+        this.log.info("This is a single package, returning changelog contents to be handled by release-it");
+        onlyContent = content;
+      }
+    }
+    return onlyContent;
   }
   async getIncrementedVersion() {
     const { newVersion } = this.getContext();

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@changesets/cli": "^2.26.0",
-    "release-it": "^15.2.0 || ^16.0.0"
+    "release-it": "^15.2.0 || ^16.0.0 || ^17.0.0"
   },
   "engines": {
     "node": ">=18.0"


### PR DESCRIPTION
Backwards compatible, which is why I went for a minor version (also to avoid the presumptuous bump to version 1.0.0). The error messages should be helpful for anyone who does try to use this.

Tested on https://github.com/lblod/frontend-embeddable-notule-editor/pull/223 with the two different variants.